### PR TITLE
Escape table to prevent error with tablenames containing a dot

### DIFF
--- a/app/scripts/services/mysql.js
+++ b/app/scripts/services/mysql.js
@@ -88,7 +88,7 @@ angular.module('electroCrudApp')
       getTableDesc: function(connection, table) {
         return new Promise(function(resolve, reject) {
           if (!connection) reject();
-          connection.query(util.format('DESC %s', table), function(err, rows, fields) {
+          connection.query(util.format('DESC `%s`', table), function(err, rows, fields) {
             if (err) reject(err);
             resolve(rows);
           });
@@ -98,7 +98,7 @@ angular.module('electroCrudApp')
         var whereSql = whereStr ? util.format('WHERE %s', whereStr) : '';
         return new Promise(function(resolve, reject) {
           if (!connection) reject();
-          connection.query(util.format('SELECT COUNT(*) as count FROM %s %s', table, whereSql), function(err, rows, fields) {
+          connection.query(util.format('SELECT COUNT(*) as count FROM `%s` %s', table, whereSql), function(err, rows, fields) {
             if (err) reject(err);
             resolve(rows[0].count);
           });
@@ -110,7 +110,7 @@ angular.module('electroCrudApp')
         whereStr = whereStr ? util.format('WHERE %s', whereStr) : '';
         return new Promise(function(resolve, reject) {
           if (!connection) reject();
-          connection.query('SELECT ?? FROM ?? '+whereStr+' ORDER BY ?? '+sortDir+' LIMIT '+limitFrom+', '+limitCount, [columns, table, sortBy], function(err, rows, fields) {
+          connection.query('SELECT ?? FROM `??` '+whereStr+' ORDER BY ?? '+sortDir+' LIMIT '+limitFrom+', '+limitCount, [columns, table, sortBy], function(err, rows, fields) {
             if (err) reject(err);
             resolve(rows);
           });
@@ -129,7 +129,7 @@ angular.module('electroCrudApp')
         console.log(where);
         return new Promise(function(resolve, reject) {
           if (!connection) reject();
-          connection.query('SELECT ?? FROM '+table+' WHERE ?', [columns, where],function(err, rows, fields) {
+          connection.query('SELECT ?? FROM `'+table+'` WHERE ?', [columns, where],function(err, rows, fields) {
             if (err) reject(err);
             resolve(rows);
           });
@@ -138,7 +138,7 @@ angular.module('electroCrudApp')
       insertData: function(connection, table, data) {
         return new Promise(function(resolve, reject) {
           if (!connection) reject();
-          connection.query('INSERT INTO '+table+' SET ?', data, function(err, rows, fields) {
+          connection.query('INSERT INTO `'+table+'` SET ?', data, function(err, rows, fields) {
             if (err) reject(err);
             resolve(rows);
           });
@@ -147,7 +147,7 @@ angular.module('electroCrudApp')
       updateData: function(connection, table, data) {
         return new Promise(function(resolve, reject) {
           if (!connection) reject();
-          connection.query('UPDATE IGNORE '+table+' SET ?', data, function(err, rows, fields) {
+          connection.query('UPDATE IGNORE `'+table+'` SET ?', data, function(err, rows, fields) {
             if (err) reject(err);
             resolve(rows);
           });
@@ -156,7 +156,7 @@ angular.module('electroCrudApp')
       deleteData: function(connection, table, data) {
         return new Promise(function(resolve, reject) {
           if (!connection) reject();
-          connection.query('DELETE FROM '+table+' WHERE ?', data, function(err, rows, fields) {
+          connection.query('DELETE FROM `'+table+'` WHERE ?', data, function(err, rows, fields) {
             if (err) reject(err);
             resolve();
           });


### PR DESCRIPTION
Steps to reproduce issue:
* create table/view with a dot f.e. users.permissions
* load the table in the app
* the app will throw an error and can't handle the table/view