### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ From version 2.7.0 SQLite has been added, currently its very limited support but
 
 ## Install via Package Managers
 ### Homebrew/brew (Mac OS/X)
-`brew cask install electrocrud`
+`brew install --cask electrocrud`
 
 ## Download Sources
 [ElectroCRUD on GitHub](https://github.com/garrylachman/ElectroCRUD)


### PR DESCRIPTION
Fix error when installing using latest Homebrew in macOS. Just fix README.md.

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103114542-53d44a80-46a2-11eb-880b-3be91115f0b9.png)