### PR TITLE
fix: force yarn install and update release config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           corepack yarn config set enableImmutableInstalls false
 
       - name: Install dependencies
-        run: corepack yarn install
+        run: corepack yarn install --force
 
       - name: Building Packages
         run: corepack yarn build
@@ -123,7 +123,7 @@ jobs:
           corepack yarn config set enableImmutableInstalls false
 
       - name: Install dependencies
-        run: corepack yarn install
+        run: corepack yarn install --force
 
       - name: Normalize Assets
         env:

--- a/.releaserc
+++ b/.releaserc
@@ -3,13 +3,55 @@
   "debug": true,
   "plugins": [
     ["@semantic-release/commit-analyzer", {
-      "preset": "angular",
+      "preset": "conventionalcommits",
       "releaseRules": [
         {"type": "docs", "release": "patch"},
-        {"type": "refactor", "release": "minor"}
-      ]
+        {"type": "refactor", "release": "patch"},
+        {"type": "style", "release": "patch"},
+        {"scope": "skip", "release": false}
+      ],
+      "presetConfig": {
+        "types": [
+          {"type": "feat", "section": "Features"},
+          {"type": "feature", "section": "Features"},
+          {"type": "fix", "section": "Bug Fixes"},
+          {"type": "perf", "section": "Performance Improvements"},
+          {"type": "revert", "section": "Reverts"},
+          {"type": "refactor", "section": "Code Refactoring"},
+          {"type": "docs", "section": "Documentation", "hidden": true},
+          {"type": "style", "section": "Styles", "hidden": true},
+          {"type": "chore", "section": "Miscellaneous Chores", "hidden": true},
+          {"type": "test", "section": "Tests", "hidden": true},
+          {"type": "build", "section": "Build System", "hidden": true},
+          {"type": "ci", "section": "Continuous Integration", "hidden": true}
+        ]
+      }
     }],
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits",
+      "releaseRules": [
+        {"type": "docs", "release": "patch"},
+        {"type": "refactor", "release": "patch"},
+        {"type": "style", "release": "patch"},
+        {"scope": "skip", "release": false}
+      ],
+      "presetConfig": {
+        "types": [
+          {"type": "feat", "section": "Features"},
+          {"type": "feature", "section": "Features"},
+          {"type": "fix", "section": "Bug Fixes"},
+          {"type": "perf", "section": "Performance Improvements"},
+          {"type": "revert", "section": "Reverts"},
+          {"type": "refactor", "section": "Code Refactoring"},
+          {"type": "docs", "section": "Documentation", "hidden": true},
+          {"type": "style", "section": "Styles", "hidden": true},
+          {"type": "chore", "section": "Miscellaneous Chores", "hidden": true},
+          {"type": "test", "section": "Tests", "hidden": true},
+          {"type": "build", "section": "Build System", "hidden": true},
+          {"type": "ci", "section": "Continuous Integration", "hidden": true}
+        ]
+      }
+    }],
     [
       "@semantic-release/changelog",
       {


### PR DESCRIPTION
This commit changes the `yarn install` command to include the `--force` flag to prevent issues with immutability. Additionally, the release configuration is updated to follow conventional commit standards, including rewording release rules and updating types and sections for release notes.

close #155 